### PR TITLE
Avoid evaluating `_Trace[S, V]` on each `_get_node` call

### DIFF
--- a/pygtrie.py
+++ b/pygtrie.py
@@ -1223,7 +1223,7 @@ class Trie(_t.Generic[K, V, S], _abc.MutableMapping[K, V]):
         # the type to make the rest of the code less noisy.  In practice, the
         # first step is never accessed and the first element is only used to
         # keep the root node.
-        return node, _t.cast(_Trace[S, V], trace)
+        return node, _t.cast('_Trace[S, V]', trace)
 
     def _set_node(self,
                   key: K,


### PR DESCRIPTION
`typing.cast` ignores its first argument at run time (its body is `return val`), but Python still evaluates that expression before making the call.  `_Trace[S, V]` subscripts a generic alias, which rebuilds the alias and calls into `typing` to substitute every type parameter, taking about 2 us each time.  As `_get_node` backs `__getitem__`, `get`, `__contains__`, `has_node`, `iteritems`, `pop` and `__delitem__`, every successful keyed lookup pays for it.  On a 2000-key `StringTrie`, `trie[key]` measures 2.66 us before this change and 0.51 us after.

The substitution is an identity one, since `S` and `V` are the module-level type variables, so all that work produces an object equal to `_Trace` itself, which `cast` then discards.

Quoting the type argument leaves nothing for the interpreter to evaluate while type checkers still read it, and matches the quoted annotations already used throughout the module.  `mypy --strict`, the test suite, the doctests and the examples are unaffected.